### PR TITLE
修复Netlify上图标不显示和丢缓存的问题

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,7 +1,11 @@
 import Image from "next/image"
 
+const loader = ({src}) => {
+    return `${src}`
+}
+
 function VSCode() {
-  return <Image src="/favicons/vscode.png" alt="" width={28} height={28} />
+  return <Image loader={loader} src="/favicons/vscode.png" alt="" width={28} height={28} />
 }
 
 export { VSCode }

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,11 +1,7 @@
 import Image from "next/image"
 
-const loader = ({src}) => {
-    return `${src}`
-}
-
 function VSCode() {
-  return <Image loader={loader} src="/favicons/vscode.png" alt="" width={28} height={28} />
+  return <Image src="/favicons/vscode.png" alt="" width={28} height={28} />
 }
 
 export { VSCode }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,9 @@ const withNextra = nextra({
  **/
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    unoptimized: true,
+  },
   swcMinify: true,
 }
 export default withNextra(nextConfig)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "rimraf .next && next build",
+    "build": "next build",
+    "build:dev": "rimraf .next && next build",
     "start": "next start",
     "lint": "next lint --fix",
     "preview": "pnpm run build && next start",


### PR DESCRIPTION
netlify不支持Next/image Optimization，因而禁用。这样应该就没有不显示图标的bug了。
[效果预览](https://vscode-docs.netlify.app/)